### PR TITLE
[Woot] Learn drops only from factory spawned mobs.

### DIFF
--- a/config/Woot.cfg
+++ b/config/Woot.cfg
@@ -114,7 +114,7 @@ general {
      >
 
     # Maximum number of mobs of each type to learn from
-    I:globalSampleSize=500
+    I:globalSampleSize=200
 
     # List of mobs and spawn costs [default: [Woot:none:IronGolem=10], [Woot:Wither:Skeleton=10], [Woot:none:MagmaCube=5], [Woot:none:Enderman=10]]
     S:globalSpawnCostList <
@@ -125,7 +125,7 @@ general {
     B:globalStrictPower=true
 
     # Learn only from mob factory spawning
-    B:globalStrictSpawns=false
+    B:globalStrictSpawns=true
 
     # List of entities that need a Tier III factory [default: [Woot:none:Enderman], [Woot:none:IronGolem], [Woot:none:Guardian], [Woot:Wither:Skeleton]]
     S:globalTierIIIMobList <


### PR DESCRIPTION
Also lowered the number of mobs needed to lock in a loot table. This will help us address an issue I'm opening.