### PR TITLE
Remove IE HV cable loss

### DIFF
--- a/config/immersiveengineering.cfg
+++ b/config/immersiveengineering.cfg
@@ -90,7 +90,7 @@ general {
     D:wireLossRatio <
         0.05
         0.025
-        0.025
+        0.0
         1.0
         1.0
         1.0


### PR DESCRIPTION
Removing HV cable power losses for distance transport. Cannot alter the "current transfer rate/max transfer rate" losses via cfg, however.