### PR TITLE
Add IE and Malisis Switches Tools to Morph Tool

### DIFF
--- a/config/Morphtool.cfg
+++ b/config/Morphtool.cfg
@@ -22,6 +22,8 @@ general {
 		embers:tinkerHammer
         appliedenergistics2:ToolNetworkTool
 		astralsorcery:ItemWand
+		immersiveengineering:tool
+		malisisswitches:powerLinker
      >
     S:"Whitelisted Names" <
         wrench


### PR DESCRIPTION
Adds the Engineers hammer (from Immersive Engineering) and the Power Linker (from Malisis' Switches) to the morph tool.  Tested locally, is functional.  Power Linker works, but only in main hand.  IE hammer works both in main and offhand for multiblock formation.  It also works for crafting, but unfortunately consumes the whole morphing tool when durability is depleted.  May need to be cut, or added as a tooltip warning?